### PR TITLE
Moving from Langchain to Ollama python library

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,26 +1,38 @@
-import eel   
+import eel
+import ollama
+import logging
 
-from langchain_community.chat_models import ChatOllama
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 eel.init("web")   
-
 LLM_MODEL = "tinyllama:chat"
+system_prompt = """
+    You are a friendly chatbot. 
+    You are helpful, kind, honest, and good at writing. 
+    You do not repeat yourself. 
+    You keep it short unless instructed otherwise.
+    """
   
 @eel.expose     
 def py_main__send_chat(chat): 
-    print(f"executing send_chat function with {chat}")
-    llm = ChatOllama(model=LLM_MODEL)
-    prompt = ChatPromptTemplate.from_messages([
-        ("system", "You are a friendly chatbot. You are helpful, kind, honest, and good at writing. You do not repeat yourself. You keep it short unless instructed otherwise."),
-        ("human", "{chat}"),
-    ])
-    chain = prompt | llm | StrOutputParser()
+    logger.info(f"executing send_chat function with {chat}")
 
-    parameters = {"chat": chat}
-
-    for chunk in chain.stream(parameters):
-        eel.js_app__updateCurrentChat(chunk)
+    stream = ollama.chat(
+        model=LLM_MODEL,
+        messages=[
+            { 
+                'role': 'system', 
+                'content': system_prompt
+            },
+            {
+                'role': 'user',
+                'content': chat
+            }
+        ],
+        stream=True,
+    )
+    for chunk in stream:
+        eel.js_app__updateCurrentChat(chunk['message']['content'])
       
 eel.start("index.html")

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "scripts": {
-    "build": "ollama pull tinyllama:chat && npm install && python3.11 -m venv ./.venv && source ./.venv/bin/activate && pip install -r requirements.txt",
+    "build": "npm install && python3.11 -m venv ./.venv && source ./.venv/bin/activate && pip install -r requirements.txt",
     "start": "esbuild ./web/src/index.jsx --bundle --outdir=./web/out && source ./.venv/bin/activate && python main.py"
   },
   "parserOptions": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 eel==0.16.0
-langchain==0.1.13
+ollama==0.1.8


### PR DESCRIPTION
Closes #18 

Removed references of LangChain out of applications and are using ollamna's python module directly to do this