### PR TITLE
Adding frontend support for multiple chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .DS_Store
 data.db
 *.pyc
+build/

--- a/backend/db/chat.py
+++ b/backend/db/chat.py
@@ -22,6 +22,13 @@ class ChatObj():
         self.id = chat.id
         self.name = chat.name
         self.created_at = chat.created_at
+    
+    def toFrontEnd(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'created_at': self.created_at.isoformat()
+        }
 
 # Database Operations
 def create(name):
@@ -40,7 +47,7 @@ def list():
     chats = Chat.select()
     return [ChatObj(chat) for chat in chats]
 
-def delete():
-    Chat.delete().execute()
+def delete(chat_id):
+    Chat.delete().where(Chat.id == chat_id).execute()
 
     

--- a/backend/db/message.py
+++ b/backend/db/message.py
@@ -27,9 +27,18 @@ class MessageObj():
         self.created_at = message.created_at
         self.chat_obj = chat.ChatObj(chat.get(message.chat_id))
 
+    def toFrontEnd(self):
+        return {
+            'id': self.id,
+            'role': self.role,
+            'content': self.content,
+            'created_at': self.created_at.isoformat(),
+            'chat': self.chat_obj.toFrontEnd()
+        }
+
 # Database Operations
-def create(role, content, chat):
-    message = Message.create(role=role, content=content, chat_id=chat.id)
+def create(role, content, chat_id):
+    message = Message.create(role=role, content=content, chat_id=chat_id)
     return MessageObj(message)
 
 def get(message_id):
@@ -44,12 +53,12 @@ def list():
     messages = Message.select()
     return [MessageObj(message) for message in messages]
 
-def list_by_chat(chat):
-    messages = Message.select().where(Message.chat_id == chat.id)
+def list_by_chat(chat_id):
+    messages = Message.select().where(Message.chat_id == chat_id)
     return [MessageObj(message) for message in messages]
 
 def delete():
     Message.delete().execute()
 
-def delete_by_chat(chat):
-    Message.delete().where(Message.chat_id == chat.id).execute()
+def delete_by_chat(chat_id):
+    Message.delete().where(Message.chat_id == chat_id).execute()

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -6,12 +6,3 @@ from db import db_instance
 def setup():
     db_instance.connect()
     db_instance.create_tables([Message, Chat])
-
-    # TODO: Temporary code to create a single "chat" object until the frontend is implemented
-    if not Chat.select().exists():
-        Chat.create(name="default")
-
-# TODO: Temporary code to return the default chat object until the frontend is implemented
-def get_default_chat():
-    return Chat.get(Chat.name == "default")
-    

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,44 +1,53 @@
 import eel
 import logging
 import constants
-from db import message
+from db import message, chat
 from llm import dispatch
-from db.utils import setup as db_setup, get_default_chat as db_get_default_chat
+from db.utils import setup as db_setup
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
-# TODO: Temporary chat object until the frontend is implemented
-default_chat = None
   
 @eel.expose
-def py_main__send_message(message_content):
+def py_main__send_message(message_content, chat_id):
     logger.info(f"executing send_message function with {message_content}")
 
-    message.create(constants.USER_ROLE, message_content, default_chat)
-    saved_messages = message.list()
+    current_chat = chat.get(chat_id)    
+
+    message.create(constants.USER_ROLE, message_content, current_chat.id)
+    saved_messages = message.list_by_chat(current_chat.id)
     stream = dispatch.send_message(saved_messages)
 
     response_message = ""
     for chunk in stream:
         # update the frontend with the llm reponse in chunks
-        eel.js_app__updateCurrentChat(chunk['message']['content']) 
+        eel.js_app__updateCurrentMessage(chunk['message']['content']) 
 
         # build the full response to save in the database
         response_message += chunk['message']['content']
     
-    message.create(constants.ASSISTANT_ROLE, response_message, default_chat)
+    message.create(constants.ASSISTANT_ROLE, response_message,  current_chat.id)
 
 @eel.expose
-def py_main__clear_messages():
-    message.delete_by_chat(default_chat)
+def py_main__delete_chat(chat_id):
+    message.delete_by_chat(chat_id)
+    chat.delete(chat_id)
+
+@eel.expose
+def py_main__create_chat(chat_name):
+    return chat.create(chat_name).toFrontEnd()
+
+@eel.expose
+def py_main__get_chats():
+    return [chatitem.toFrontEnd() for chatitem in chat.list()]
+    
+@eel.expose
+def py_main__get_messages_by_chat(chat_id):
+    return [messageitem.toFrontEnd() for messageitem in message.list_by_chat(chat_id)]
 
 def main():
     db_setup()
-
-    # TODO: Temporary code to return the default chat object until the frontend is implemented
-    global default_chat
-    default_chat = db_get_default_chat()
 
     eel.init(constants.FRONTEND_FOLDER)
     eel.start(constants.FRONTEND_INDEX_PAGE)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,41 +1,87 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import MessageForm from "./components/MessageForm";
 import MessageArea from "./components/MessageArea";
+import ChatList from "./components/ChatList";
 import * as Constants from "./utils/constants";
 
 function App() {
-  const [chatHistory, setChatHistory] = useState([Constants.INTRO_MESSAGE]);
-  const [currentChat, setCurrentChat] = useState("");
+  const [messageHistory, setMessageHistory] = useState([]);
+  const [currentMessage, setCurrentMessage] = useState("");
+  const [currentChatID, setCurrentChatID] = useState(Constants.NEW_CHAT_ID);
+  const [allChats, setAllChats] = useState([]);
+
+  useEffect(() => {
+    eel.py_main__get_chats()((result) => {
+      setAllChats(result);
+      onChatNew();
+    })
+  }, []);
+
+  const onChatNew = () => { 
+    setMessageHistory([])
+    setCurrentMessage("")
+    setCurrentChatID(Constants.NEW_CHAT_ID)
+  }
+
+  const onChatSelect = (chatID) => {
+    eel.py_main__get_messages_by_chat(chatID)((result) => {
+      setMessageHistory(result.map((message) => `${message.role}: ${message.content}`));
+      setCurrentMessage("")
+    });
+    setCurrentChatID(chatID);
+  };
 
   const onSubmitForm = (textValue) => {
-    if (currentChat === "") {
-      setChatHistory([...chatHistory, `${Constants.USER_ROLE_NAME}: ${textValue}`]);
+    if (currentMessage === "") {
+      setMessageHistory([...messageHistory, `${Constants.USER_ROLE_NAME}: ${textValue}`]);
     } else {
-      setChatHistory([...chatHistory, currentChat, `\n${Constants.USER_ROLE_NAME}: ${textValue}`]);
+      setMessageHistory([...messageHistory, currentMessage, `\n${Constants.USER_ROLE_NAME}: ${textValue}`]);
     }
-    setCurrentChat(`${Constants.ASSISTANT_ROLE_NAME}: `);
-    eel.py_main__send_message(textValue)();
+    setCurrentMessage(`${Constants.ASSISTANT_ROLE_NAME}: `);
+
+    if (currentChatID === Constants.NEW_CHAT_ID) {
+      eel.py_main__create_chat(textValue.slice(0, Constants.NEW_CHAT_NAME_NUM_CHARS))((newChat) => {
+        setAllChats([...allChats, newChat]);
+        setCurrentChatID(newChat.id);
+        eel.py_main__send_message(textValue, newChat.id)();
+      });
+    } else {
+      eel.py_main__send_message(textValue, currentChatID)();
+    }
+    
   };
 
-  const onClearForm = () => {
-    setCurrentChat("");
-    setChatHistory([Constants.INTRO_MESSAGE]);
-    eel.py_main__clear_messages()();
-  };
+  const onChatDelete = () => {
+    setAllChats((prevState) => prevState.filter((chat) => chat.id !== currentChatID));
+    eel.py_main__delete_chat(currentChatID)(() => {
+      onChatNew();
+    });
+  }
 
-  eel.expose(js_app__updateCurrentChat);
-  function js_app__updateCurrentChat(chunk) {
-    setCurrentChat((prevState) => prevState + chunk);
+  eel.expose(js_app__updateCurrentMessage);
+  function js_app__updateCurrentMessage(chunk) {
+    setCurrentMessage((prevState) => prevState + chunk);
   }
 
   return (
     <div className="mg-container">
-      <div className="mg-row message-area">
-        <MessageArea chatHistory={chatHistory} currentChat={currentChat} />
+      <div className="mg-row">
+
+        <div className="mg-col mg-x3">
+          <div className="mg-row grid-cel chat-list">
+            <ChatList allChats={allChats} currentChatID={currentChatID} onChatSelect={onChatSelect} />
+          </div>
+        </div>
+
+        <div className="mg-col mg-x9">
+          <div className="mg-row grid-cel message-area">
+            <MessageArea messageHistory={messageHistory} currentMessage={currentMessage} />
+          </div>
+        </div>
       </div>
       <div className="mg-row message-form">
-        <MessageForm onSubmitForm={onSubmitForm} onClearForm={onClearForm} />
+        <MessageForm onSubmitForm={onSubmitForm} onDeleteChat={onChatDelete} onNewChat={onChatNew} />
       </div>
     </div>
   );

--- a/frontend/src/components/ChatList.jsx
+++ b/frontend/src/components/ChatList.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+function ChatList({ allChats, currentChatID, onChatSelect }) {
+
+    return (
+        <div className="mg-col mg-x12">
+            <ul>
+            {allChats.map((chat) => (
+            <li key={chat.id} onClick={() => onChatSelect(chat.id)} className={(chat.id == currentChatID) ? 'selected':''}>
+                {chat.name}
+            </li>
+            ))}
+        </ul>
+    </div>
+    );
+}
+export default ChatList;

--- a/frontend/src/components/MessageArea.jsx
+++ b/frontend/src/components/MessageArea.jsx
@@ -1,18 +1,18 @@
 import React, { useEffect, useRef } from "react";
 
-function MessageArea({ chatHistory, currentChat }) {
+function MessageArea({ messageHistory, currentMessage }) {
     const historyAreaRef = useRef(null);
 
     useEffect(() => {
       historyAreaRef.current.scrollTop = historyAreaRef.current.scrollHeight;
-    }, [chatHistory, currentChat]);
+    }, [messageHistory, currentMessage]);
 
     return (
       <div className="mg-col mg-x12">
         <pre>
           <code ref={historyAreaRef}>
-            {chatHistory.map((chat) => chat + "\n")}
-            {currentChat && currentChat + "\n"}
+            {messageHistory && messageHistory.length > 0 && messageHistory.map((message) => message + "\n====================\n")}
+            {currentMessage}
           </code>
         </pre>
       </div>

--- a/frontend/src/components/MessageForm.jsx
+++ b/frontend/src/components/MessageForm.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-function MessageForm({ onSubmitForm, onClearForm }) {
+function MessageForm({ onSubmitForm, onDeleteChat, onNewChat}) {
 
   const [messageValue, setMessageValue] = useState("");
 
@@ -14,9 +14,15 @@ function MessageForm({ onSubmitForm, onClearForm }) {
     setMessageValue("");
   }
 
-  const handleClear = (event) => {
+  const handleDeleteChat = (event) => {
     event.preventDefault();
-    onClearForm();
+    onDeleteChat();
+    setMessageValue();
+  }
+
+  const handleNewChat = (event) => {
+    event.preventDefault();
+    onNewChat();
     setMessageValue();
   }
 
@@ -38,9 +44,12 @@ function MessageForm({ onSubmitForm, onClearForm }) {
         </div>
         <div className="mg-row">
           <div className="mg-col mg-x2">
-            <button className="mg-bg-tertiary" style={{ border: 'none' }} onClick={handleClear}>Clear</button>
+            <button className="mg-bg-tertiary" style={{ border: 'none' }} onClick={handleDeleteChat}>Delete Chat</button>
           </div>
-          <div className="mg-col, mg-x8"></div>
+          <div className="mg-col mg-x2">
+            <button className="mg-bg-tertiary" style={{ border: 'none' }} onClick={handleNewChat}>New Chat</button>
+          </div>
+          <div className="mg-col, mg-x6"></div>
           <div className="mg-col mg-x2">
             <button>Send</button>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,10 +1,22 @@
 .message-area pre code {
     white-space: pre-wrap;
-    min-height: calc(100vh - 225px);
+    min-height: calc(100vh - 250px);
     max-height: 25em;
     overflow: auto;
 }
 
 .message-form {
     height: 225px;
+}
+
+.chat-list {
+    margin-top: 20px
+}
+
+.chat-list li {
+    cursor: pointer;
+}
+
+.chat-list .selected {
+    font-weight: bold;
 }

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,8 +1,5 @@
-export const INTRO_MESSAGE = 
-`******************************
-Welcome to Personal LLM! Ask me anything! Enter in the form below
-******************************\n`;
+export const USER_ROLE_NAME = "user";
+export const ASSISTANT_ROLE_NAME = "assistant";
 
-export const USER_ROLE_NAME = "User";
-export const ASSISTANT_ROLE_NAME = "Assistant";
-
+export const NEW_CHAT_ID = 0;
+export const NEW_CHAT_NAME_NUM_CHARS = 20;


### PR DESCRIPTION
- Added front end support for multiple chats
- Added ChatList component to hold chats, able to switch between chats on click
- Added DeleteChat and NewChat buttons for chat functionality
- Removed all temporary code refering to the one default chat
- Added .toFrontEnd functions for ChatObj and MessageObj classes to convert instance to dictionary to be available in the front end (through python-eel)