### PR TITLE
Creating dedicated eel function modules

### DIFF
--- a/backend/api/functions.py
+++ b/backend/api/functions.py
@@ -1,0 +1,56 @@
+import eel
+import logging
+import constants
+from db import message, chat
+from llm import dispatch
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+# Functions defined in the front end that can be called from the backend
+
+def js_update_current_message(message):
+    eel.jsUpdateCurrentMessage(message)   
+
+
+# Functions defined in the backend that can be called from the frontend
+
+@eel.expose
+def py_send_message(message_content, chat_id):
+    logger.info(f"executing send_message function with {message_content}")
+
+    current_chat = chat.get(chat_id)    
+
+    message.create(constants.USER_ROLE, message_content, current_chat.id)
+    saved_messages = message.list_by_chat(current_chat.id)
+    stream = dispatch.send_message(saved_messages)
+
+    response_message = ""
+    for chunk in stream:
+        # update the frdontend with the llm reponse in chunks
+        js_update_current_message(chunk['message']['content']) 
+
+        # build the full response to save in the database
+        response_message += chunk['message']['content']
+    
+    message.create(constants.ASSISTANT_ROLE, response_message,  current_chat.id)
+
+@eel.expose
+def py_delete_chat(chat_id):
+    message.delete_by_chat(chat_id)
+    chat.delete(chat_id)
+
+@eel.expose
+def py_create_chat(chat_name):
+    return chat.create(chat_name).toFrontEnd()
+
+@eel.expose
+def py_get_chats():
+    return [chatitem.toFrontEnd() for chatitem in chat.list()]
+    
+@eel.expose
+def py_get_messages_by_chat(chat_id):
+    return [messageitem.toFrontEnd() for messageitem in message.list_by_chat(chat_id)]
+
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,50 +1,11 @@
 import eel
 import logging
 import constants
-from db import message, chat
-from llm import dispatch
+import api.functions
 from db.utils import setup as db_setup
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
-
-  
-@eel.expose
-def py_main__send_message(message_content, chat_id):
-    logger.info(f"executing send_message function with {message_content}")
-
-    current_chat = chat.get(chat_id)    
-
-    message.create(constants.USER_ROLE, message_content, current_chat.id)
-    saved_messages = message.list_by_chat(current_chat.id)
-    stream = dispatch.send_message(saved_messages)
-
-    response_message = ""
-    for chunk in stream:
-        # update the frontend with the llm reponse in chunks
-        eel.js_app__updateCurrentMessage(chunk['message']['content']) 
-
-        # build the full response to save in the database
-        response_message += chunk['message']['content']
-    
-    message.create(constants.ASSISTANT_ROLE, response_message,  current_chat.id)
-
-@eel.expose
-def py_main__delete_chat(chat_id):
-    message.delete_by_chat(chat_id)
-    chat.delete(chat_id)
-
-@eel.expose
-def py_main__create_chat(chat_name):
-    return chat.create(chat_name).toFrontEnd()
-
-@eel.expose
-def py_main__get_chats():
-    return [chatitem.toFrontEnd() for chatitem in chat.list()]
-    
-@eel.expose
-def py_main__get_messages_by_chat(chat_id):
-    return [messageitem.toFrontEnd() for messageitem in message.list_by_chat(chat_id)]
 
 def main():
     db_setup()

--- a/frontend/src/api/functions.js
+++ b/frontend/src/api/functions.js
@@ -1,0 +1,35 @@
+
+
+// backend functions to be called from the frontend
+export const pySendMessage = (message, chatID, callback=()=>{}) => {
+    eel.py_send_message(message, chatID)(callback);
+};
+
+export const pyDeleteChat = (chatID, callback=()=>{}) => {
+    eel.py_delete_chat(chatID)(callback);
+};
+
+export const pyGetChats = (callback=()=>{}) => {
+    eel.py_get_chats()(callback);
+};
+
+export const pyCreateChat = (name, callback=()=>{}) => {
+    eel.py_create_chat(name)(callback);
+};
+
+export const pyGetMessagesByChat = (chatID, callback=()=>{}) => {
+    eel.py_get_messages_by_chat(chatID)(callback);
+};
+
+
+// In case an eel function that is exposed to the backend
+// requires dynamically created resources, use 
+// eelResources to pass those resources here
+export const eelResources = {}
+
+// frontend functions to be called from the backend
+
+eel.expose(jsUpdateCurrentMessage);
+function jsUpdateCurrentMessage(chunk) {
+    eelResources.jsUpdateCurrentMessage.setCurrentMessage((prevState) => prevState + chunk);
+}


### PR DESCRIPTION
Adding modules in both front end and back end code to have a repository of all of the defined eel functions are located.

Goal is to use this refactor to provide one place on the frontend and on the backend where eel functions are defined, which define the interface between the two surfaces.